### PR TITLE
Feature/event based deploys

### DIFF
--- a/src/Actions/DeployAction.php
+++ b/src/Actions/DeployAction.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Itiden\StatamicBuddy\Actions;
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+
+final class DeployAction
+{
+    public function handle(string $comment)
+    {
+        $host = config('statamic-buddy.host');
+        $token = config('statamic-buddy.token');
+        $workspace = config('statamic-buddy.workspace');
+        $project = config('statamic-buddy.project');
+        $pipelineId = config('statamic-buddy.pipeline');
+
+        $response = Http::withToken($token)
+            ->post("https://$host/workspaces/$workspace/projects/$project/pipelines/$pipelineId/executions", [
+                "to_revision" => [
+                    "revision" => "HEAD"
+                ],
+                "comment" => $comment
+            ]);
+
+        Cache::forget('buddy-deploy-api');
+
+        return $response;
+    }
+}

--- a/src/Http/Controllers/Api/DeployApiController.php
+++ b/src/Http/Controllers/Api/DeployApiController.php
@@ -3,37 +3,15 @@
 namespace Itiden\StatamicBuddy\Http\Controllers\Api;
 
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\Http;
+use Itiden\StatamicBuddy\Actions\DeployAction;
 use Statamic\Http\Controllers\Controller;
 
 class DeployApiController extends Controller
 {
-  public function __invoke(Request $request)
+  public function __invoke(Request $request, DeployAction $deployAction)
   {
-    $response = $this->deploy($request->get('comment', ''));
+    $response = $deployAction->handle($request->get('comment', ''));
 
     return response()->json($response->json());
-  }
-
-  private function deploy(string $comment)
-  {
-    $host = config('statamic-buddy.host');
-    $token = config('statamic-buddy.token');
-    $workspace = config('statamic-buddy.workspace');
-    $project = config('statamic-buddy.project');
-    $pipelineId = config('statamic-buddy.pipeline');
-
-    $response = Http::withToken($token)
-      ->post("https://$host/workspaces/$workspace/projects/$project/pipelines/$pipelineId/executions", [
-          "to_revision" => [
-              "revision" => "HEAD"
-          ],
-          "comment" => $comment
-      ]);
-
-    Cache::forget('buddy-deploy-api');
-
-    return $response;
   }
 }

--- a/src/Listeners/DeployListener.php
+++ b/src/Listeners/DeployListener.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Itiden\StatamicBuddy\Listeners;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Support\Facades\Log;
+use Itiden\StatamicBuddy\Actions\DeployAction;
+use Statamic\Contracts\Git\ProvidesCommitMessage;
+use Statamic\Events\AssetDeleted;
+use Statamic\Events\EntryCreated;
+use Statamic\Events\EntryDeleted;
+use Statamic\Events\EntrySaved;
+use Statamic\Events\GlobalSetCreated;
+use Statamic\Events\GlobalSetDeleted;
+use Statamic\Events\GlobalSetSaved;
+use Statamic\Events\TermCreated;
+use Statamic\Events\TermDeleted;
+use Statamic\Events\TermSaved;
+
+final class DeployListener
+{
+    public function __construct(
+        protected DeployAction $deployAction,
+    ) {}
+
+    private function handleEntry($event): void
+    {
+        if ($event->entry->isDirty() && $event->entry->published()) {
+            $this->deployAction->handle(
+                'Entry updated or created: ' . $event->entry->id()
+            );
+            return;
+        }
+
+        Log::info('Nothing to deploy');
+    }
+
+    public function handleGlobalSet($event): void
+    {
+        $this->deployAction->handle(
+            'Global set updated or created: ' . $event->globals->handle(),
+        );
+    }
+
+    public function handleTerm($event): void
+    {
+        $this->deployAction->handle(
+            'Term updated or created: ' . $event->term->id()
+        );
+    }
+
+    private function handleDelete($event): void
+    {
+        $this->deployAction->handle('Deleted : ' . $event::class);
+    }
+
+    /**
+     * Register the listeners for the subscriber.
+     */
+    public function subscribe(Dispatcher $events)
+    {
+
+        $events->listen([EntrySaved::class, EntryCreated::class], $this->handleEntry(...));
+
+        $events->listen([GlobalSetSaved::class, GlobalSetCreated::class], $this->handleGlobalSet(...));
+
+        $events->listen([TermSaved::class, TermCreated::class], $this->handleTerm(...));
+
+        $events->listen([
+            EntryDeleted::class,
+            GlobalSetDeleted::class,
+            TermDeleted::class,
+            AssetDeleted::class,
+        ], $this->handleDelete(...));
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Itiden\StatamicBuddy;
 
+use Itiden\StatamicBuddy\Listeners\DeployListener;
 use Statamic\Providers\AddonServiceProvider;
 use Statamic\Facades\CP\Nav;
 
@@ -13,6 +14,10 @@ class ServiceProvider extends AddonServiceProvider
 
     protected $scripts = [
         __DIR__.'/../dist/js/index.js',
+    ];
+
+    protected $subscribe = [
+        DeployListener::class
     ];
 
     public function bootAddon()


### PR DESCRIPTION
Listen to
`EntrySaved`, `EntryCreated`, `EntryDeleted`,
`GlobalSetSaved`, `GlobalSetCreated`, `GlobalSetDeleted`,
`TermSaved`, `TermCreated`, `TermDeleted`,
`AssetDeleted` and trigger deploy when they are hit.

An entry has to be published and dirty to be deployed, the other events don't have access to an isDirty method.

TODO

- [ ] There should probably be some opt-in/out config value.